### PR TITLE
Add settings menu

### DIFF
--- a/common/hooks.ts
+++ b/common/hooks.ts
@@ -1,0 +1,42 @@
+import { useState } from "preact/hooks";
+export function useLocalStorage<T>(key: string, initialValue: T): [T, (v: T) => any] {
+    // State to store our value
+    // Pass initial state function to useState so logic is only executed once
+    const [storedValue, setStoredValue] = useState(() => {
+        if (typeof window === "undefined") {
+            return initialValue;
+        }
+
+        try {
+            // Get from local storage by key
+            const item = window.localStorage.getItem(key);
+            // Parse stored json or if none return initialValue
+            return item ? JSON.parse(item) : initialValue;
+        } catch (error) {
+            // If error also return initialValue
+            console.log(error);
+            return initialValue;
+        }
+    });
+
+    // Return a wrapped version of useState's setter function that ...
+    // ... persists the new value to localStorage.
+    const setValue = (value: any) => {
+        try {
+            // Allow value to be a function so we have same API as useState
+            const valueToStore =
+                value instanceof Function ? value(storedValue) : value;
+            // Save state
+            setStoredValue(valueToStore);
+            // Save to local storage
+            if (typeof window !== "undefined") {
+                window.localStorage.setItem(key, JSON.stringify(valueToStore));
+            }
+        } catch (error) {
+            // A more advanced implementation would handle the error case
+            console.log(error);
+        }
+    };
+
+    return [storedValue, setValue];
+}

--- a/common/icons.tsx
+++ b/common/icons.tsx
@@ -24,6 +24,7 @@ import IconFlipHorizontal from "tabler_icons_tsx/tsx/flip-horizontal.tsx";
 import IconArrowBarUp from "tabler_icons_tsx/tsx/arrow-bar-up.tsx";
 import IconArrowBarDown from "tabler_icons_tsx/tsx/arrow-bar-down.tsx";
 import IconPrinter from "tabler_icons_tsx/tsx/printer.tsx";
+import IconSettings from "tabler_icons_tsx/tsx/settings.tsx";
 import { INL_ICON_COLOR, INL_ICON_SIZE } from "./constants.ts";
 
 export const Icons = {
@@ -53,6 +54,7 @@ export const Icons = {
     IconArrowBarDown,
     IconX,
     IconPrinter,
+    IconSettings
 };
 
 for (const key in Icons) {

--- a/components/Printer.tsx
+++ b/components/Printer.tsx
@@ -43,10 +43,6 @@ export default function Printer(props: PrinterProps) {
         return data;
     }, {});
 
-    let [finishFeed] = useLocalStorage<number>('finishFeed', 120);
-    let [speed] = useLocalStorage<number>('speed', 32);
-    let [energy] = useLocalStorage<number>('energy', 0x5000);
-
     let [settingsVisible, setSettingsVisible] = useState(false)
 
     const stuffs = props.stuffs;
@@ -63,6 +59,10 @@ export default function Printer(props: PrinterProps) {
         )}
     </div>;
     const print = async () => {
+        let speed = localStorage.getItem("speed");
+        let energy = localStorage.getItem("energy");
+        let finishFeed = localStorage.getItem("finishFeed");
+
         const device = await navigator.bluetooth.requestDevice({
             filters: [{ services: [ CAT_ADV_SRV ] }],
             optionalServices: [ CAT_PRINT_SRV ]

--- a/components/Printer.tsx
+++ b/components/Printer.tsx
@@ -8,6 +8,8 @@ import { _ } from "../common/i18n.tsx";
 import { CatPrinter } from "../common/cat-protocol.ts";
 import { delay } from "https://deno.land/std@0.193.0/async/delay.ts";
 import {useLocalStorage} from "../common/hooks.ts";
+import Settings from "./Settings.tsx";
+import { useState } from "preact/hooks";
 
 declare let navigator: Navigator & {
     // deno-lint-ignore no-explicit-any
@@ -44,6 +46,8 @@ export default function Printer(props: PrinterProps) {
     let [finishFeed] = useLocalStorage<number>('finishFeed', 120);
     let [speed] = useLocalStorage<number>('speed', 32);
     let [energy] = useLocalStorage<number>('energy', 0x5000);
+
+    let [settingsVisible, setSettingsVisible] = useState(false)
 
     const stuffs = props.stuffs;
     if (stuffs.length === 0)
@@ -108,10 +112,16 @@ export default function Printer(props: PrinterProps) {
             if (server) server.disconnect();
         }
     };
-    const print_menu = <div class="print-menu">
-        <button class="stuff stuff--button" aria-label={_('print')} onClick={print}>
-            <Icons.IconPrinter />
-        </button>
+    const print_menu = <div>
+        <div class="print-menu">
+            <button class="stuff stuff--button" style={{width:"80%"}} aria-label={_('print')} onClick={print}>
+                <Icons.IconPrinter />
+            </button>
+            <button class="stuff stuff--button" style={{width:"20%"}} aria-label={_('settings')} onClick={()=>setSettingsVisible(!settingsVisible)}>
+                <Icons.IconSettings />
+            </button>
+        </div>
+        <Settings visible={settingsVisible}/>
     </div>;
     return <>
         {preview}

--- a/components/Settings.tsx
+++ b/components/Settings.tsx
@@ -1,0 +1,30 @@
+import {useLocalStorage} from "../common/hooks.ts";
+import {_} from "../common/i18n.tsx";
+
+export default function (){
+    let [finishFeed, setFinishFeed] = useLocalStorage<number>('finishFeed', 120);
+    let [speed, setSpeed] = useLocalStorage<number>('speed', 32);
+    let [energy, setEnergy] = useLocalStorage<number>('energy', 0x5000);
+
+    //TODO: Make hard limits for the values
+
+    return <>
+        <p>Settings</p>
+
+        <div className="stuff__option">
+            <span className="option__title">{_('Finish feed')}</span>
+            <input className="option__item" type="number" value={finishFeed} onInput={(e:any)=>setFinishFeed(e.target.value)}/>
+
+        </div>
+        <div className="stuff__option">
+            <span className="option__title">{_('Speed')}</span>
+            <input className="option__item" type="number" value={speed} onInput={(e:any)=>setSpeed(e.target.value)}/>
+
+        </div>
+        <div className="stuff__option">
+            <span className="option__title">{_('Energy')}</span>
+            <input className="option__item" type="number" value={energy} onInput={(e:any)=>setEnergy(e.target.value)}/>
+
+        </div>
+    </>
+}

--- a/components/Settings.tsx
+++ b/components/Settings.tsx
@@ -3,11 +3,9 @@ import {_} from "../common/i18n.tsx";
 import {Icons} from "../common/icons.tsx";
 
 export default function ({visible}:{visible:boolean}){
-    let [finishFeed, setFinishFeed] = useLocalStorage<number>('finishFeed', 120);
+    let [finishFeed, setFinishFeed] = useLocalStorage<number>('finishFeed', 100);
     let [speed, setSpeed] = useLocalStorage<number>('speed', 32);
-    let [energy, setEnergy] = useLocalStorage<number>('energy', 0x5000);
-
-    //TODO: Make hard limits for the values
+    let [energy, setEnergy] = useLocalStorage<number>('energy', 24000);
 
     return <div className={`${visible?"print__options-container--visible":""} print__options-container`}>
         <div className="stuff__option">
@@ -53,19 +51,19 @@ export default function ({visible}:{visible:boolean}){
 
         <div className="stuff__option">
             <span className="option__title">{_('Energy')}</span>
-            <button className="option__item" value={0x4000}
-                    onClick={()=>setEnergy(0x4000)}
-                    data-selected={energy === 0x4000}>
+            <button className="option__item" value={12000}
+                    onClick={()=>setEnergy(12000)}
+                    data-selected={energy === 12000}>
                 <span className="stuff__label">{_('Low')}</span>
             </button>
-            <button className="option__item" value={0x5000}
-                    onClick={()=>setEnergy(0x5000)}
-                    data-selected={energy === 0x5000}>
+            <button className="option__item" value={24000}
+                    onClick={()=>setEnergy(24000)}
+                    data-selected={energy === 24000}>
                 <span className="stuff__label">{_('Medium')}</span>
             </button>
-            <button className="option__item" value={0x6000}
-                    onClick={()=>setEnergy(0x6000)}
-                    data-selected={energy === 0x6000}>
+            <button className="option__item" value={48000}
+                    onClick={()=>setEnergy(48000)}
+                    data-selected={energy === 48000}>
                 <span className="stuff__label">{_('High')}</span>
             </button>
 

--- a/components/Settings.tsx
+++ b/components/Settings.tsx
@@ -1,30 +1,75 @@
 import {useLocalStorage} from "../common/hooks.ts";
 import {_} from "../common/i18n.tsx";
+import {Icons} from "../common/icons.tsx";
 
-export default function (){
+export default function ({visible}:{visible:boolean}){
     let [finishFeed, setFinishFeed] = useLocalStorage<number>('finishFeed', 120);
     let [speed, setSpeed] = useLocalStorage<number>('speed', 32);
     let [energy, setEnergy] = useLocalStorage<number>('energy', 0x5000);
 
     //TODO: Make hard limits for the values
 
-    return <>
-        <p>Settings</p>
-
+    return <div className={`${visible?"print__options-container--visible":""} print__options-container`}>
         <div className="stuff__option">
             <span className="option__title">{_('Finish feed')}</span>
-            <input className="option__item" type="number" value={finishFeed} onInput={(e:any)=>setFinishFeed(e.target.value)}/>
-
+            <button className="option__item" value="0"
+                    onClick={()=>setFinishFeed(0)}
+                    data-selected={finishFeed === 0}>
+                <span className="stuff__label">{_('0')}</span>
+            </button>
+            <button className="option__item" value="50"
+                    onClick={()=>setFinishFeed(50)}
+                    data-selected={finishFeed === 50}>
+                <span className="stuff__label">{_('50')}</span>
+            </button>
+            <button className="option__item" value="100"
+                    onClick={()=>setFinishFeed(100)}
+                    data-selected={finishFeed === 100}>
+                <span className="stuff__label">{_('100')}</span>
+            </button>
+            <input className="option__item" type="number" min={0} max={65535} value={finishFeed} onInput={(e:any)=>setFinishFeed(e.target.value)}/>
         </div>
+
         <div className="stuff__option">
             <span className="option__title">{_('Speed')}</span>
-            <input className="option__item" type="number" value={speed} onInput={(e:any)=>setSpeed(e.target.value)}/>
+            <button className="option__item" value="8"
+                    onClick={()=>setSpeed(8)}
+                    data-selected={speed === 8}>
+                <span className="stuff__label">{_('Fastest')}</span>
+            </button>
+            <button className="option__item" value="16"
+                    onClick={()=>setSpeed(16)}
+                    data-selected={speed === 16}>
+                <span className="stuff__label">{_('Fast')}</span>
+            </button>
+            <button className="option__item" value="32"
+                    onClick={()=>setSpeed(32)}
+                    data-selected={speed === 32}>
+                <span className="stuff__label">{_('Good Quality')}</span>
+            </button>
 
+            <input className="option__item" type="number" min={4} max={255} value={speed} onInput={(e:any)=>setSpeed(e.target.value)}/>
         </div>
+
         <div className="stuff__option">
             <span className="option__title">{_('Energy')}</span>
-            <input className="option__item" type="number" value={energy} onInput={(e:any)=>setEnergy(e.target.value)}/>
+            <button className="option__item" value={0x4000}
+                    onClick={()=>setEnergy(0x4000)}
+                    data-selected={energy === 0x4000}>
+                <span className="stuff__label">{_('Low')}</span>
+            </button>
+            <button className="option__item" value={0x5000}
+                    onClick={()=>setEnergy(0x5000)}
+                    data-selected={energy === 0x5000}>
+                <span className="stuff__label">{_('Medium')}</span>
+            </button>
+            <button className="option__item" value={0x6000}
+                    onClick={()=>setEnergy(0x6000)}
+                    data-selected={energy === 0x6000}>
+                <span className="stuff__label">{_('High')}</span>
+            </button>
 
+            <input className="option__item" type="number" min={0} max={0xFFFF} value={energy} onInput={(e:any)=>setEnergy(e.target.value)}/>
         </div>
-    </>
+    </div>
 }

--- a/components/Settings.tsx
+++ b/components/Settings.tsx
@@ -27,7 +27,7 @@ export default function ({visible}:{visible:boolean}){
                     data-selected={finishFeed === 100}>
                 <span className="stuff__label">{_('100')}</span>
             </button>
-            <input className="option__item" type="number" min={0} max={65535} value={finishFeed} onInput={(e:any)=>setFinishFeed(e.target.value)}/>
+            <input className="option__item" type="number" min={0} max={65535} value={finishFeed} onInput={(e:any)=>setFinishFeed(+e.target.value)}/>
         </div>
 
         <div className="stuff__option">
@@ -48,7 +48,7 @@ export default function ({visible}:{visible:boolean}){
                 <span className="stuff__label">{_('Good Quality')}</span>
             </button>
 
-            <input className="option__item" type="number" min={4} max={255} value={speed} onInput={(e:any)=>setSpeed(e.target.value)}/>
+            <input className="option__item" type="number" min={4} max={255} value={speed} onInput={(e:any)=>setSpeed(+e.target.value)}/>
         </div>
 
         <div className="stuff__option">
@@ -69,7 +69,7 @@ export default function ({visible}:{visible:boolean}){
                 <span className="stuff__label">{_('High')}</span>
             </button>
 
-            <input className="option__item" type="number" min={0} max={0xFFFF} value={energy} onInput={(e:any)=>setEnergy(e.target.value)}/>
+            <input className="option__item" type="number" min={0} max={0xFFFF} value={energy} onInput={(e:any)=>setEnergy(+e.target.value)}/>
         </div>
     </div>
 }

--- a/islands/Nav.tsx
+++ b/islands/Nav.tsx
@@ -2,11 +2,9 @@ import { createRef } from "preact";
 import { _ } from "../common/i18n.tsx";
 import { IS_BROWSER } from "$fresh/runtime.ts";
 import { NavProps } from "../common/types.ts";
-import Settings from "../components/Settings.tsx";
 
 export default function NavBar(props: NavProps) {
     const ref_about = createRef();
-    const ref_settings = createRef();
     const url = new URL(props.url);
     return <>
         <nav class="nav">
@@ -17,9 +15,6 @@ export default function NavBar(props: NavProps) {
             </div>
             <div class="nav-links">
                 <a class="nav-links__link" href="javascript:" onClick={() => ref_about.current.classList.toggle('about--visible')}>{_('about')}</a>
-            </div>
-            <div class="nav-links">
-                <a class="nav-links__link" href="javascript:" onClick={() => ref_settings.current.classList.toggle('settings--visible')}>{_('Settings')}</a>
             </div>
         </nav>
         <div class="about" ref={ref_about}>
@@ -36,9 +31,6 @@ export default function NavBar(props: NavProps) {
                     />
                 </a>
             </p>
-        </div>
-        <div class="settings" ref={ref_settings}>
-            <Settings/>
         </div>
         <noscript>
             <p class="noscript">

--- a/islands/Nav.tsx
+++ b/islands/Nav.tsx
@@ -2,9 +2,11 @@ import { createRef } from "preact";
 import { _ } from "../common/i18n.tsx";
 import { IS_BROWSER } from "$fresh/runtime.ts";
 import { NavProps } from "../common/types.ts";
+import Settings from "../components/Settings.tsx";
 
 export default function NavBar(props: NavProps) {
     const ref_about = createRef();
+    const ref_settings = createRef();
     const url = new URL(props.url);
     return <>
         <nav class="nav">
@@ -15,6 +17,9 @@ export default function NavBar(props: NavProps) {
             </div>
             <div class="nav-links">
                 <a class="nav-links__link" href="javascript:" onClick={() => ref_about.current.classList.toggle('about--visible')}>{_('about')}</a>
+            </div>
+            <div class="nav-links">
+                <a class="nav-links__link" href="javascript:" onClick={() => ref_settings.current.classList.toggle('settings--visible')}>{_('Settings')}</a>
             </div>
         </nav>
         <div class="about" ref={ref_about}>
@@ -31,6 +36,9 @@ export default function NavBar(props: NavProps) {
                     />
                 </a>
             </p>
+        </div>
+        <div class="settings" ref={ref_settings}>
+            <Settings/>
         </div>
         <noscript>
             <p class="noscript">

--- a/static/styles.css
+++ b/static/styles.css
@@ -371,6 +371,7 @@ p {
 
 .print-menu {
     margin: 0 1em;
+    display: flex;
 }
 
 .fresh-logo {
@@ -415,4 +416,19 @@ p {
     .fresh-logo {
         background: url('https://fresh.deno.dev/fresh-badge-dark.svg');
     }
+}
+
+.print-menu > .stuff--button{
+    margin: 5px;
+}
+
+.print__options-container {
+    max-height: 0;
+    transition: max-height 0.2s cubic-bezier(.08,.82,.17,1);
+    overflow-x: visible;
+    overflow-y: auto;
+}
+.print__options-container:focus-within,
+.print__options-container--visible {
+    max-height: 12em;
 }

--- a/static/styles.css
+++ b/static/styles.css
@@ -243,6 +243,10 @@ p {
     box-sizing: content-box;
 }
 
+.kitty-preview > img {
+    width: 100%;
+}
+
 .stuff {
     border: 1px solid var(--gray-1);
     transition: box-shadow 0.2s ease;

--- a/static/styles.css
+++ b/static/styles.css
@@ -57,7 +57,7 @@ input[type="text"] {
 }
 input[type="number"],
 input[inputmode="numeric"] {
-    width: 4em;
+    width: 6em;
 }
 
 button,
@@ -198,8 +198,23 @@ p {
     margin-bottom: 1em;
     transition: height 0.3s cubic-bezier(.08,.82,.17,1);
 }
+
+.settings {
+    text-align: center;
+    height: 0;
+    overflow: hidden;
+    pointer-events: none;
+    border-bottom: 1px solid var(--gray-1);
+    margin-bottom: 1em;
+    transition: height 0.3s cubic-bezier(.08,.82,.17,1);
+}
 .about--visible {
     height: 10em;
+    pointer-events: unset;
+}
+
+.settings--visible {
+    height: 15em;
     pointer-events: unset;
 }
 


### PR DESCRIPTION
I'm working on settings menu as you mentioned in the TODOs (make energy, speed and feed customisable. For now I've made simple settings menu as your About menu. The settings are stored in localstorage. 
![image](https://github.com/NaitLee/kitty-printer/assets/54410730/09e6d6f5-d38c-4ea6-9cd9-ac55fef77eb1)

Don't merge it just yet, it's still WIP. Do you have any knowledge or resources on what is the range of these parameters, or in what units are they? I'll be implementing some settings from the Cat-Printer.

I'm looking forward for your suggestions or edits. 